### PR TITLE
Do not call clear when resetting the color

### DIFF
--- a/Colorify/Format.cs
+++ b/Colorify/Format.cs
@@ -46,7 +46,6 @@ namespace Colorify
             lock (colorLock)
             {
                 Console.ResetColor();
-                Clear();
             }
         }
 


### PR DESCRIPTION
I don't know why is that there, but since the Clear method is also exposed there's no need to clear after a colorreset. Actually, I don't want it, cause I would loose everything in the console just because I wanted the following text to be reset to the console's default.