### PR TITLE
Sometimes WindowWidth returns 0

### DIFF
--- a/Colorify/Terminal/Out.cs
+++ b/Colorify/Terminal/Out.cs
@@ -11,7 +11,7 @@ namespace Colorify.Terminal
 
         public static void WriteLine(string text)
         {
-            int size = Console.WindowWidth - 1;
+			int size = Console.WindowWidth - 1;
             if (size != Console.CursorLeft + 1)
             {
                 size = size - Console.CursorLeft;
@@ -20,7 +20,11 @@ namespace Colorify.Terminal
             {
                 size = Console.WindowWidth + size;
             }
-            Console.WriteLine($"{text.PadRight(size)}");
+
+			if (size < 0)
+				size = text.Length;
+
+			Console.WriteLine($"{text.PadRight(size)}");
         }
 
         public static void AlignRight(string text)

--- a/Colorify/Terminal/Out.cs
+++ b/Colorify/Terminal/Out.cs
@@ -11,7 +11,7 @@ namespace Colorify.Terminal
 
         public static void WriteLine(string text)
         {
-			int size = Console.WindowWidth - 1;
+            int size = Console.WindowWidth - 1;
             if (size != Console.CursorLeft + 1)
             {
                 size = size - Console.CursorLeft;
@@ -21,10 +21,10 @@ namespace Colorify.Terminal
                 size = Console.WindowWidth + size;
             }
 
-			if (size < 0)
-				size = text.Length;
+            if (size < 0)
+                size = text.Length;
 
-			Console.WriteLine($"{text.PadRight(size)}");
+            Console.WriteLine($"{text.PadRight(size)}");
         }
 
         public static void AlignRight(string text)


### PR DESCRIPTION
When an app is running inside a Docker container `Console.WindowWidth` returns 0, thus the PadRight was throwing an `ArgumentOutOfRangeException`.

Added an innocent check, just in case.