### PR TITLE
Default colors should be default and not arbitrary set

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,2 @@
+[*.cs]
+indent_style = space

--- a/Colorify/Theme/ThemeAction.cs
+++ b/Colorify/Theme/ThemeAction.cs
@@ -3,11 +3,21 @@ using System.Collections.Generic;
 
 namespace Colorify.UI
 {
-    public class ThemeAction
+    public abstract class ThemeAction : ITheme
     {
         protected ConsoleColor _defaultBackground { get; set; }
         protected ConsoleColor _defaultForeground { get; set; }
 
+        public Dictionary<string, Color> _colors { get; set; }
+
+        public abstract void SetColors();
+
+        public ThemeAction()
+        {
+            _defaultBackground = Console.BackgroundColor;
+            _defaultForeground = Console.ForegroundColor;
+            SetColors();
+        }
         public Color AddColor(ConsoleColor? background, ConsoleColor? foreground)
         {
             var color = new Color(

--- a/Colorify/Theme/ThemeDark.cs
+++ b/Colorify/Theme/ThemeDark.cs
@@ -14,18 +14,9 @@ namespace Colorify.UI
         }
     }
 
-    public sealed class ThemeDark : ThemeAction, ITheme
+    public sealed class ThemeDark : ThemeAction
     {
-        public ThemeDark()
-        {
-            base._defaultBackground = ConsoleColor.Black;
-            base._defaultForeground = ConsoleColor.White;
-            SetColors();
-        }
-
-        public Dictionary<string, Color> _colors { get; set; }
-
-        public void SetColors()
+        public override void SetColors()
         {
             var colors = new Dictionary<string, Color>();
             colors.Add("text-default", AddColor(null, null));

--- a/Colorify/Theme/ThemeLight.cs
+++ b/Colorify/Theme/ThemeLight.cs
@@ -14,18 +14,9 @@ namespace Colorify.UI
         }
     }
 
-    public sealed class ThemeLight : ThemeAction, ITheme
+    public sealed class ThemeLight : ThemeAction
     {
-        public ThemeLight()
-        {
-            base._defaultBackground = ConsoleColor.White;
-            base._defaultForeground = ConsoleColor.Black;
-            SetColors();
-        }
-
-        public Dictionary<string, Color> _colors { get; set; }
-
-        public void SetColors()
+        public override void SetColors()
         {
             var colors = new Dictionary<string, Color>();
             colors.Add("text-default", AddColor(null, null));

--- a/Sample/Sample.csproj
+++ b/Sample/Sample.csproj
@@ -1,10 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <ItemGroup>
+    <PackageReference Include="dein.Colorify" Version="2.0.1" />
     <PackageReference Include="dein.ToolBox" Version="1.4.1" />
     <PackageReference Include="Newtonsoft.Json" Version="11.0.2" />
-  </ItemGroup>
-  <ItemGroup>
-    <ProjectReference Include="..\Colorify\Colorify.csproj" />
   </ItemGroup>
   <PropertyGroup>
     <OutputType>Exe</OutputType>

--- a/Sample/Sample.csproj
+++ b/Sample/Sample.csproj
@@ -1,8 +1,10 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <ItemGroup>
-    <PackageReference Include="dein.Colorify" Version="2.0.1" />
     <PackageReference Include="dein.ToolBox" Version="1.4.1" />
     <PackageReference Include="Newtonsoft.Json" Version="11.0.2" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\Colorify\Colorify.csproj" />
   </ItemGroup>
   <PropertyGroup>
     <OutputType>Exe</OutputType>


### PR DESCRIPTION
I did a little refactoring and moved some things around.
Default colors were being set arbitrary to back or white while they should be the user's current colors. I also added a .editorconfig file cause I prefer tabs but respect your spaces preferences :)
I also modified the Sample project so it references the Colorify project instead of the Nuget package.

Thank you for your work here... it's literally making my life a lot easier 👍 